### PR TITLE
feat: PIZ-4 added CI workflow with GitHubActions 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: Pizza Planet Continuous Integration
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test_pull_request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest --cov --cov-fail-under=90
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.x
+      - name: Setup Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ pycodestyle==2.8.0
 pyflakes==2.4.0
 pyparsing==3.0.7
 pytest==6.2.5
+pytest-cov==4.0.0
 pytest-assume==2.4.3
 six==1.16.0
 SQLAlchemy==1.4.31


### PR DESCRIPTION
Why?
In order to have a CI workflow that runs on every pull request to the main branch

New files:

- .github/workflows/main.yml
